### PR TITLE
Ensure proper URL encoding and update API2 format note

### DIFF
--- a/PxApiConverter/Business/ConvertUtil.cs
+++ b/PxApiConverter/Business/ConvertUtil.cs
@@ -1,6 +1,7 @@
 ﻿using PCAxis.Paxiom;
 using PxWeb.Api2.Server.Models;
 using System.Text;
+using System.Web;
 
 namespace sq_migrate
 {
@@ -166,7 +167,13 @@ namespace sq_migrate
             var sb = new StringBuilder();
             foreach (var selection in selections.Selection)
             {
-                sb.Append($"&valueCodes[{selection.VariableCode}]={string.Join(',', selection.ValueCodes.Select(c => c.Contains(',') ? $"[{c}]" : c))}");
+                var encodedValues = selection.ValueCodes.Select(vc =>
+                {
+                    var enc = Uri.EscapeDataString(vc);
+                    return vc.Contains(',') ? $"[{enc}]" : enc;
+                });
+
+                sb.Append($"&valueCodes[{selection.VariableCode}]={string.Join(',', encodedValues)}");
                 if (!string.IsNullOrWhiteSpace(selection.CodeList))
                 {
                     sb.Append($"&codeList[{selection.VariableCode}]={selection.CodeList}");

--- a/PxApiConverter/Views/Home/Index.cshtml
+++ b/PxApiConverter/Views/Home/Index.cshtml
@@ -8,7 +8,7 @@
 <div class="row">
     <div class="col-lg-8 col-xl-7">
         <div class="alert alert-info mb-4" role="alert">
-            Note: The JsonStat format is not supported in API2.
+            Note: The JsonStat and SDMX formats are not supported in API2.
         </div>
         <form id="convertForm" method="post" action="@Url.Action("ConvertResult", "Home")" class="mb-4">
             <div class="mb-3">


### PR DESCRIPTION
Updated `ConvertUtil.cs` to use `Uri.EscapeDataString` for proper URL encoding of `valueCodes`, ensuring special characters are handled correctly. Added `System.Web` namespace to support this functionality.

In `Index.cshtml`, updated the informational message to indicate that the "SDMX" format is also not supported in API2, alongside the "JsonStat" format.