### PR TITLE
Improve error handling in HomeController

### DIFF
--- a/PxApiConverter/Controllers/HomeController.cs
+++ b/PxApiConverter/Controllers/HomeController.cs
@@ -68,8 +68,7 @@ namespace PxApiConverter.Controllers
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Conversion failed");
-                // Return the real exception message as requested
-                return BadRequest(new { error = ex.Message });
+                return BadRequest(new { error = "Conversion failed" });
             }
         }
     }


### PR DESCRIPTION
Modified the error response in `HomeController.cs` to return a generic message "Conversion failed" instead of the actual exception message. This change enhances security by preventing the exposure of detailed exception information to the client.