### PR TITLE
Update branding and remove contact section

### DIFF
--- a/PxApiConverter/Views/Home/Index.cshtml
+++ b/PxApiConverter/Views/Home/Index.cshtml
@@ -19,8 +19,6 @@
     <div class="col-lg-8 col-xl-7">
         <div class="mb-4" >
             This converter allows you to transform a PxWebApi 1 query into a PxWebApi 2-compliant query.
-            <br />
-            <span class="fw-bold">Contact:</span> <a href="mailto:px@scb.se?subject=PxWebApi%20Converter%20Support" class="text-decoration-none">px@scb.se</a>
         </div>
         <div class="alert alert-info mb-4" role="alert">           
             Note: The JsonStat and SDMX formats are not supported in API2.
@@ -41,7 +39,7 @@
         </form>
 
         <div id="results" class="d-none">
-            <h2 class="h5 mb-3">Resultat</h2>
+            <h2 class="h5 mb-3">Result</h2>
             <div class="mb-3">
                 <div class="d-flex justify-content-between align-items-center mb-1">
                     <label >

--- a/PxApiConverter/Views/Shared/_Layout.cshtml
+++ b/PxApiConverter/Views/Shared/_Layout.cshtml
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@ViewData["Title"] - PxApiConverter</title>
+    <title>@ViewData["Title"] - PxWebApi converter</title>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/PxApiConverter.styles.css" asp-append-version="true" />
@@ -12,7 +12,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">PxApiConverter</a>
+                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">PxWebApi converter</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -32,7 +32,7 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2025 - PxApiConverter
+            &copy; 2025 - PxWebApi converter
         </div>
     </footer>
     <script src="~/lib/jquery/dist/jquery.min.js"></script>


### PR DESCRIPTION
Updated the application name from "PxApiConverter" to "PxWebApi converter" across the `<title>`, navbar, and footer in `_Layout.cshtml`. Removed the "Contact" section from `Index.cshtml`, which included an email link for support. Changed the heading in `Index.cshtml` from "Resultat" to "Result" to align with the English locale.